### PR TITLE
Move antimalware scanner out of configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,20 @@ In order to use the antimalware scanning capabilities, ensure you have a ByteGua
 ### Basic validation
 
 ```csharp
+// Without antimalware scanner
 var configuration = new FileValidatorConfiguration
 {
   SupportedFileTypes = [FileExtensions.Pdf, FileExtensions.Jpg, FileExtensions.Png],
   FileSizeLimit = ByteSize.MegaBytes(25),
-  ThrowExceptionOnInvalidFile = false,
-  AntimalwareScanner = new SpecificAntimalwareScanner(scannerOptions)
+  ThrowExceptionOnInvalidFile = false
 };
 
 var fileValidator = new FileValidator(configuration);
+var isValid = fileValidator.IsValidFile("example.pdf", fileStream);
+
+// With antimalware
+var antimalwareScanner = AntimalwareScannerImplementation();
+var fileValidator = new FileValidator(configuration, antimalwareScanner);
 var isValid = fileValidator.IsValidFile("example.pdf", fileStream);
 ```
 
@@ -60,7 +65,6 @@ var configuration = new FileValidatorConfigurationBuilder()
   .AllowFileTypes(FileExtensions.Pdf, FileExtensions.Jpg, FileExtensions.Png)
   .SetFileSizeLimit(ByteSize.MegaBytes(25))
   .SetThrowExceptionOnInvalidFile(false)
-  .AddAntimalwareScanner(new SpecificAntimalwareScanner(scannerOptions))
   .Build();
 
 var fileValidator = new FileValidator(configuration);
@@ -96,15 +100,16 @@ public async Task<IActionResult> Upload(IFormFile file)
 {
     using var stream = file.OpenReadStream();
 
+    var antimalwareScanner = AntimalwareScannerImplementation();
+
     var configuration = new FileValidatorConfiguration
     {
         SupportedFileTypes = [FileExtensions.Pdf, FileExtensions.Docx],
         FileSizeLimit = ByteSize.MegaBytes(10),
-        ThrowExceptionOnInvalidFile = false,
-        AntimalwareScanner = new SpecificAntimalwareScanner(scannerOptions)
+        ThrowExceptionOnInvalidFile = false
     };
 
-    var validator = new FileValidator(configuration);
+    var validator = new FileValidator(configuration, antimalwareScanner);
 
     if (!validator.IsValidFile(file.FileName, stream))
     {
@@ -170,7 +175,6 @@ The `FileValidatorConfiguration` supports:
 | `SupportedFileTypes` | Yes | N/A | A list of allowed file extensions (e.g., `.pdf`, `.jpg`).<br>Use the predefined constants in `FileExtensions` for supported types. |
 | `FileSizeLimit` | Yes | N/A | Maximum permitted size of files.<br>Use the static  `ByteSize` class provided with this package, to simplify your limit. |
 | `ThrowExceptionOnInvalidFile` | No | `true` | Whether to throw an exception on invalid files or return `false`. |
-| `AntimalwareScanner` | No | N/A | An antimalware scanner used to scan the given file for potential malware. |
 
 ### Exceptions
 

--- a/src/ByteGuard.FileValidator/Configuration/FileValidatorConfiguration.cs
+++ b/src/ByteGuard.FileValidator/Configuration/FileValidatorConfiguration.cs
@@ -29,10 +29,5 @@ namespace ByteGuard.FileValidator.Configuration
         /// Whether to throw an exception if an unsupported/invalid file is encountered. Defaults to <c>true</c>.
         /// </summary>
         public bool ThrowExceptionOnInvalidFile { get; set; } = true;
-
-        /// <summary>
-        /// Optional antimalware scanner to use during file validation.
-        /// </summary>
-        public IAntimalwareScanner? AntimalwareScanner { get; set; } = null;
     }
 }

--- a/src/ByteGuard.FileValidator/Configuration/FileValidatorConfigurationBuilder.cs
+++ b/src/ByteGuard.FileValidator/Configuration/FileValidatorConfigurationBuilder.cs
@@ -10,7 +10,6 @@ namespace ByteGuard.FileValidator.Configuration
         private readonly List<string> supportedFileTypes = new List<string>();
         private bool throwOnInvalidFiles = true;
         private long fileSizeLimit = ByteSize.MegaBytes(25);
-        private IAntimalwareScanner? antimalwareScanner = null;
 
         /// <summary>
         /// Allow specific file types (extensions) to be validated.
@@ -45,22 +44,6 @@ namespace ByteGuard.FileValidator.Configuration
         }
 
         /// <summary>
-        /// Add an antimalware scanner.
-        /// </summary>
-        /// <param name="scanner">Antimalware scanner to use.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the provided scanner is null.</exception>
-        public FileValidatorConfigurationBuilder AddAntimalwareScanner(IAntimalwareScanner scanner)
-        {
-            if (scanner == null)
-            {
-                throw new ArgumentNullException(nameof(scanner));
-            }
-
-            antimalwareScanner = scanner;
-            return this;
-        }
-
-        /// <summary>
         /// Build configuration.
         /// </summary>
         /// <returns>File validator configurations object.</returns>
@@ -70,8 +53,7 @@ namespace ByteGuard.FileValidator.Configuration
             {
                 SupportedFileTypes = supportedFileTypes,
                 ThrowExceptionOnInvalidFile = throwOnInvalidFiles,
-                FileSizeLimit = fileSizeLimit,
-                AntimalwareScanner = antimalwareScanner
+                FileSizeLimit = fileSizeLimit
             };
 
             ConfigurationValidator.ThrowIfInvalid(configuration);

--- a/tests/ByteGuard.FileValidator.Tests.Unit/FileValidatorTests.cs
+++ b/tests/ByteGuard.FileValidator.Tests.Unit/FileValidatorTests.cs
@@ -1073,10 +1073,9 @@ public class FileValidatorTests
         {
             SupportedFileTypes = [".pdf"],
             FileSizeLimit = ByteSize.MegaBytes(25),
-            ThrowExceptionOnInvalidFile = true,
-            AntimalwareScanner = mockAntimalwareScanner
+            ThrowExceptionOnInvalidFile = true
         };
-        var fileValidator = new FileValidator(config);
+        var fileValidator = new FileValidator(config, mockAntimalwareScanner);
         var fileBytes = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D }; // Valid PDF signature
 
         // Act
@@ -1097,10 +1096,9 @@ public class FileValidatorTests
         {
             SupportedFileTypes = [".pdf"],
             FileSizeLimit = ByteSize.MegaBytes(25),
-            ThrowExceptionOnInvalidFile = false,
-            AntimalwareScanner = mockAntimalwareScanner
+            ThrowExceptionOnInvalidFile = false
         };
-        var fileValidator = new FileValidator(config);
+        var fileValidator = new FileValidator(config, mockAntimalwareScanner);
         var fileBytes = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D }; // Valid PDF signature
 
         // Act


### PR DESCRIPTION
As antimalware scanning is more of a dependency extension with logic and less of a data configuration, it should be provided as a parameter to the file validator, instead of via configuration.