### PR TITLE
Default to stream instead of byte array

### DIFF
--- a/src/ByteGuard.FileValidator/FileValidator.cs
+++ b/src/ByteGuard.FileValidator/FileValidator.cs
@@ -995,7 +995,7 @@ namespace ByteGuard.FileValidator
 
             using (var memoryStream = new MemoryStream(content))
             {
-                return IsValidOpenDocumentFormat(fileName, content);
+                return IsValidOpenDocumentFormat(fileName, memoryStream);
             }
         }
 

--- a/src/ByteGuard.FileValidator/Validators/PdfValidator.cs
+++ b/src/ByteGuard.FileValidator/Validators/PdfValidator.cs
@@ -41,7 +41,7 @@ namespace ByteGuard.FileValidator.Validators
         /// <param name="stream">Content stream</param>
         /// <param name="leaveOpen">Whether the stream should be closed during dispose.</param>
         /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="stream"/> is <c>null</c> or empty.</exception>
-        public PdfValidator(Stream stream, bool leaveOpen = false)
+        public PdfValidator(Stream stream, bool leaveOpen = true)
         {
             if (stream == null || stream.Length == 0)
             {


### PR DESCRIPTION
Increase in performance and decrease in memory usage.

There's no need for us to potentially load 5GB files into memory if the overload using Stream is used, as we potentially only need to read a signature of e.g. 8 bytes.